### PR TITLE
Update restore API docs

### DIFF
--- a/library/restore.md
+++ b/library/restore.md
@@ -27,7 +27,7 @@ See [this report](https://app.wandb.ai/lavanyashukla/save_and_restore/reports/Sa
 
 ```python
 # restore a model file from a specific run by user "vanpelt" in "my-project"
-best_model = wandb.restore('best-model.h5', run_path="vanpelt/my-project/a1b2c3d")
+best_model = wandb.restore('model-best.h5', run_path="vanpelt/my-project/a1b2c3d")
 
 # restore a weights file from a checkpoint
 # (NOTE: resuming must be configured if run_path is not provided)


### PR DESCRIPTION
The current restore docs can cause confusion, since by default model files get saves as `model-best.h5` but in the docs we refer to it as `best-model.h5`. The error messages in the CLI compound the confusion, since the error message indicates a permissions issue.