### PR TITLE
Missing `)` in a code snippet

### DIFF
--- a/library/log.md
+++ b/library/log.md
@@ -115,7 +115,7 @@ img = wandb.Image(image, boxes={
     }
 })
 
-wandb.log({"driving_scene": img}
+wandb.log({"driving_scene": img})
 ```
 
 Optional Parameters


### PR DESCRIPTION
Due to the fact that the code snippets can be copied directly from the website, it is only fair that the snippets are syntactically correct. In the code of b_box there was a missing `)` that has been added.