### PR TITLE
[doc] Fix minor typo hiding `save_model` argument

### DIFF
--- a/library/reference/keras.md
+++ b/library/reference/keras.md
@@ -50,12 +50,13 @@ WandbCallback can optionally save training and validation data for wandb to visu
 **Arguments**:
 
 * `monitor` _str_ - name of metric to monitor.  Defaults to val\_loss.
-* `mode` _str_ - one of {"auto", "min", "max"}. "min" - save model when monitor is minimized "max" - save model when monitor is maximized "auto" - try to guess when to save the model \(default\). save\_model: True - save a model when monitor beats all previous epochs False - don't save models
+* `mode` _str_ - one of {"auto", "min", "max"}. "min" - save model when monitor is minimized "max" - save model when monitor is maximized "auto" - try to guess when to save the model \(default\). 
 * `save_weights_only` _boolean_ - if True, then only the model's weights will be saved \(`model.save_weights(filepath)`\), else the full model is saved \(`model.save(filepath)`\).
-* `log_weights` - \(boolean\) if True save histograms of the model's layer's weights.
-* `log_gradients` - \(boolean\) if True log histograms of the training gradients. The model must define a `total_loss`.
-* `training_data` - \(tuple\) Same format \(X,y\) as passed to model.fit.  This is needed for calculating gradients - this is mandatory if `log_gradients` is `True`.
-* `validation_data` - \(tuple\) Same format \(X,y\) as passed to model.fit.  A set of data for wandb to visualize.  If this is set, every epoch, wandb will make a small number of predictions and save the results for later visualization.
+* `log_weights` _boolean_ - if True save histograms of the model's layer's weights.
+* `log_gradients` _boolean_ - if True log histograms of the training gradients. The model must define a `total_loss`.
+* `save_model` _boolean_ - if True, save a model when monitor beats all previous epochs, else don't save models
+* `training_data` _tuple_ - Same format \(X,y\) as passed to model.fit.  This is needed for calculating gradients - this is mandatory if `log_gradients` is `True`.
+* `validation_data` _tuple_ - Same format \(X,y\) as passed to model.fit.  A set of data for wandb to visualize.  If this is set, every epoch, wandb will make a small number of predictions and save the results for later visualization.
 * `generator` _generator_ - a generator that returns validation data for wandb to visualize.  This generator should return tuples \(X,y\).  Either validate\_data or generator should be set for wandb to visualize specific data examples.
 * `validation_steps` _int_ - if `validation_data` is a generator, how many steps to run the generator for the full validation set.
 * `labels` _list_ - If you are visualizing your data with wandb this list of labels will convert numeric output to understandable string if you are building a multiclass classifier.  If you are making a binary classifier you can pass in a list of two labels \["label for false", "label for true"\].  If validate\_data and generator are both false, this won't do anything.


### PR DESCRIPTION
## Expected
I was looking for `WandbCallback(save_model)` in the [docs](https://docs.wandb.ai/ref/keras) and couldn't see it at first.

## Actual
<img width="801" alt="Screenshot 2021-01-21 at 11 14 39" src="https://user-images.githubusercontent.com/637130/105344655-244e2a80-5bdb-11eb-9e27-dc075b5ead2c.png">

## Fix
[doc] Fix minor typo hiding `save_model` argument

I double-checked the source and kept the argument order consistent: https://github.com/wandb/client/blob/79c0a74e0c37bbe2c81cb5286ae0e63ef4afa014/wandb/integration/keras/keras.py#L209-L301

[nit] I also changed formatting of type info on 4 other args for consistency. 
```diff
- * `log_weights` - \(boolean\) if True ... 
+ * `log_weights` _boolean_ - if True ...
```

## Result
<img width="957" alt="Screenshot 2021-01-21 at 11 21 19" src="https://user-images.githubusercontent.com/637130/105344668-2adca200-5bdb-11eb-8848-8d2c23f6048c.png">
