### PR TITLE
[en] Update to the PyTorch guide for logging images and media

### DIFF
--- a/guides/integrations/pytorch.md
+++ b/guides/integrations/pytorch.md
@@ -55,9 +55,9 @@ For more on logging rich media to W\&B in PyTorch and other frameworks, check ou
 If you also want to include information alongside media, like your model's predictions or derived metrics, use a `wandb.Table`.
 
 ```python
-my_table = wandb.Table()
+my_table = wandb.Table(columns=[])
 
-my_table.add_column("image", images_t)
+my_table.add_column("image", [wandb.Image(im) for im in images_t])
 my_table.add_column("label", labels)
 my_table.add_column("class_prediction", predictions_t)
 


### PR DESCRIPTION
There are two errors in the code of the guide for logging images into the Table given [here](https://docs.wandb.ai/guides/integrations/pytorch#logging-images-and-media). 

First, creating a table by `wandb.Table()` without any arguments defaults to creating a Table with three columns: Input, Output and Expected as given [here](https://github.com/wandb/client/blob/master/wandb/data_types.py#L263) and as no data is given in the construction it will crate an empty row as given [here](https://github.com/wandb/client/blob/master/wandb/data_types.py#L284). This means that adding new columns with some number of rows, e.g. n, as given in the guide will result in the AssertionError: Expected length 0, found n in `add_column` [here](https://github.com/wandb/client/blob/master/wandb/data_types.py#L804). So for this guide to work construction of a Table should be done by `wandb.Table(columns=[])`.

The second error is more of an ambiguity and given in `my_table.add_column("image", images_t)`. Here it is not defined what is `images_t` but looking to the previous section of the code it says `images_t = ...  # generate or load images as PyTorch Tensors`. However, passing PyTorch tensor to the `add_column` results in an AssertionError [here](https://github.com/wandb/client/blob/master/wandb/data_types.py#L801) as there is a check that passed data is either a list or numpy array. So that line should be changed to something like `my_table.add_column("image", [wandb.Image(im) for im in images_t])`.